### PR TITLE
dSCC calculation added for the model

### DIFF
--- a/dSCC.m
+++ b/dSCC.m
@@ -1,0 +1,33 @@
+function dSCC = dSCC(chromosome_file, alpha, method_type)
+    % dSCC: Calculate the dSCC value for a given chromosome
+    % INPUTS:
+    % chromosome_file: Path to the chromosome contact map (square matrix) file
+    % alpha: Scaling factor for freq2dist
+    % method_type: ShNeigh method type (1 or 2)
+    % OUTPUT:
+    % dSCC: Spearman correlation coefficient between original and reconstructed distances
+
+    % Load the chromosome contact map
+    heatmapMatrix = load(chromosome_file);
+
+    % Run ShNeigh to get reconstructed coordinates
+    [posMatrix, ~] = ShNeigh(heatmapMatrix, method_type);
+    reconstructed_coords = posMatrix(:, 2:4);
+
+    % Compute reconstructed distances
+    reconstructed_distances = pdist(reconstructed_coords);
+    reconstructed_flattened = squareform(reconstructed_distances);
+    reconstructed_flattened = reconstructed_flattened(:);
+
+    % Filter the original heatmap to match valid nodes
+    selbin = sum(heatmapMatrix > 0) > 2;
+    filtered_heatmap = heatmapMatrix(selbin, selbin);
+    original_distances = freq2dist(filtered_heatmap, alpha, 1.0);
+    original_flattened = original_distances(:);
+
+    % Compute Spearman correlation
+    dSCC = corr(original_flattened, reconstructed_flattened, 'Type', 'Spearman');
+
+    % Display the result
+    disp(['dSCC value for ', chromosome_file, ': ', num2str(dSCC)]);
+end

--- a/matFilter.m
+++ b/matFilter.m
@@ -6,7 +6,8 @@ heatmapMatrix=heatmapMatrix(selbin,:);
 heatmapMatrix=heatmapMatrix(:,selbin);
 
 FreqMat=heatmapMatrix;
-[num_parts,comps]=graphconncomp(sparse(FreqMat),'Weak', 1);
+comps = conncomp(graph(sparse(FreqMat)));
+num_parts = max(comps);
 %%make sure connected   
 if num_parts>1
     compstat=tabulate(comps);


### PR DESCRIPTION
dSCC calculation matlab file for the ShNeigh model. The graphconcomp is no longer available so change in matFilter.m file with this line:conncomp(graph(sparse(FreqMat))); and with the dSCC.m file, you can calculate the dSCC values for each chromosome with the method.